### PR TITLE
Allow to define a maximum size for the queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "test": "xo && ava",
-    "test-watch": "ava --watch"
+    "test-watch": "ava --watch --verbose"
   },
   "files": [
     "index.js"

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ More examples available in [test.js](test.js)
 
 ## API
 
-### batcher(method, interval)
+### batcher(method, settings)
 
 Returns a batch method to wrap each call to be batched. Use one for each purpose.
 
@@ -48,12 +48,17 @@ Type: `function`
 
 The method to be batched
 
-#### interval
+#### settings
 
-Type: `number`
-Default: 0
+Type: `object`
+Default: {
+	interval: 0,
+	maximum: null
+}
 
-The interval between calls to be batched - defaults to 0 meaning that only calls in the same cycle of the event loop are going to be batched; Increase the number for more tolerance.
+Custom settings for the batcher. It allows to customize:
+	- `interval`:  the interval between calls to be batched - defaults to 0 meaning that only calls in the same cycle of the event loop are going to be batched; Increase the number for more tolerance.
+	- `maximum`: the maximum ammount of calls to be batched - defaults to null or no limit. Use this number if your api has a limit.
 
 
 ### batch(options, callback)

--- a/test.js
+++ b/test.js
@@ -134,3 +134,53 @@ test.cb('should allow to define a custom interval', t => {
 		}, 10);
 	}, 5);
 });
+
+test.cb('should allow to define a maximum limit', t => {
+	t.plan(4);
+
+	const myMethod = sinon.spy();
+
+	const batch = batcher(myMethod, {maximum: 2});
+	const callback = () => undefined;
+
+	batch({id: 1}, callback);
+	batch({id: 2}, callback);
+	batch({id: 3}, callback);
+	batch({id: 4}, callback);
+	batch({id: 5}, callback);
+
+	setTimeout(() => {
+		t.true(myMethod.calledThrice);
+		t.true(myMethod.calledWith([{id: 1}, {id: 2}]));
+		t.true(myMethod.calledWith([{id: 3}, {id: 4}]));
+		t.true(myMethod.calledWith([{id: 5}]));
+		t.end();
+	}, 5);
+});
+
+test.cb('should allow to define a maximum limit with custom intervals', t => {
+	t.plan(5);
+
+	const myMethod = sinon.spy();
+
+	const batch = batcher(myMethod, {maximum: 2, interval: 1});
+	const callback = () => undefined;
+
+	batch({id: 1}, callback);
+	batch({id: 2}, callback);
+	batch({id: 3}, callback);
+	batch({id: 4}, callback);
+	batch({id: 5}, callback);
+
+	setTimeout(() => {
+		batch({id: 6}, callback);
+		t.true(myMethod.calledWith([{id: 1}, {id: 2}]));
+		t.true(myMethod.calledWith([{id: 3}, {id: 4}]));
+		t.true(myMethod.calledWith([{id: 5}]));
+		setTimeout(() => {
+			t.true(myMethod.calledWith([{id: 6}]));
+			t.true(myMethod.getCalls().length === 4);
+			t.end();
+		}, 5);
+	}, 5);
+});


### PR DESCRIPTION
This PR adds the capability to define the maximum size of the calls to batch. Once it reaches the maximum, it executes the function and clear the queue.

It's useful in cases where your api has a limit.

cc: @marcodejongh 