### PR TITLE
Make both payload and callback optional

### DIFF
--- a/batcher-js-tests.ts
+++ b/batcher-js-tests.ts
@@ -1,0 +1,53 @@
+// This code does not run, but it is type-checked.
+
+import Batcher from ".";
+
+{
+    const myMethod = (payloads: any[]) => undefined;
+    const batch = Batcher(myMethod);
+
+    batch(); // No callback, e.g. batch MobX action (synchronous).
+    batch(undefined, () => 123);
+    batch({}, () => 123);
+}
+
+{
+    const myMethod = (
+        payloads: Array<{ id: number }>,
+        callback: () => undefined,
+    ) => undefined;
+
+    const batch = Batcher(myMethod);
+    batch({ id: 1 }, () => undefined);
+}
+
+{
+    const myMethod = (payloads: Array<{ id: number }>) => undefined;
+
+    Batcher(myMethod, 10);
+    Batcher(myMethod, { maximum: 2 });
+    Batcher(myMethod, { maximum: 2, interval: 1 });
+}
+
+{
+    let loading = 10;
+
+    let stop = () => {
+        loading--;
+    };
+
+    /**
+     * Reduces flicker on front end.
+     */
+    const lazyStop = () => {
+        stop = Batcher(decrease, 500);
+    };
+
+    const decrease = (calls: any[]) => {
+        loading -= calls.length;
+    };
+
+    if (typeof window !== "undefined") {
+        lazyStop();
+    }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for batcher-js 1.0.1
+// Project: https://github.com/leandrowd/batcher
+// Definitions by: makepost <https://github.com/makepost>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Groups calls in a given interval using a function hash. Like a
+ * debounce but you don't miss intermediate calls.
+ */
+export default function Batcher<T>(
+  method: (payloads: T[], callback?: any) => void,
+
+  /**
+   * Custom settings for the batcher, or just the interval.
+   */
+  settings?: {
+    /**
+     * How long to wait before executing callback. If 0, only batches calls
+     * in same event loop cycle.
+     */
+    interval?: number
+
+    /**
+     * Callback and start fresh after this many calls. Use if your api
+     * has a limit.
+     */
+    maximum?: number,
+  } | number,
+): (
+  /**
+   * Pushed to an Array, passed to the method at the end of the batch.
+   */
+  payload?: T,
+
+  /**
+   * The callback to be passed to the batched method. Calls are grouped
+   * based on the hash of this method.
+   */
+  callback?: any,
+) => void;

--- a/index.js
+++ b/index.js
@@ -70,10 +70,6 @@ module.exports = function (method, settings) {
 	}
 
 	return function (options, callback) {
-		if (typeof options === 'undefined') {
-			throw new TypeError('Missing parameters in batched call');
-		}
-
 		var collector = aggregate(options, callback);
 		var executor = get(executors, callback);
 		if (executor) {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "batcher-js",
   "version": "1.0.1",
   "description": "Batching with ease",
+  "main": "index",
+  "typings": "index",
   "license": "MIT",
   "repository": "https://github.com/leandrowd/batcher",
   "author": {
@@ -13,7 +15,7 @@
     "node": ">=6"
   },
   "scripts": {
-    "test": "xo && ava",
+    "test": "xo && tsc && tslint *.ts && ava",
     "test-watch": "ava --watch --verbose",
     "prepublish-to-npm": "git pull && npm test",
     "publish-to-npm": "(git pull origin master && npm version patch && git push origin master && npm publish && git push --tags)"
@@ -30,6 +32,8 @@
     "ava": "^0.15.0",
     "sinon": "^1.17.5",
     "tap-diff": "^0.1.1",
+    "tslint": "^5.8.0",
+    "typescript": "^2.6.1",
     "xo": "^0.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "batcher-js",
   "version": "1.0.1",
-  "description": "Batching with ease",
+  "description": "Batching with ease, like debounce but you don't miss intermediate calls",
   "main": "index",
   "typings": "index",
   "license": "MIT",
@@ -26,7 +26,8 @@
   "keywords": [
     "batch",
     "function",
-    "async"
+    "async",
+    "debounce"
   ],
   "devDependencies": {
     "ava": "^0.15.0",

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,16 @@ batch({id: 7}, callback2);
 
 More examples available in [test.js](test.js)
 
+### TypeScript
+
+Definitions are included.
+
+```typescript
+import Batcher from "batcher-js";
+```
+
+More examples available in [batcher-js-tests.ts](batcher-js-tests.ts)
+
 ## API
 
 ### batcher(method, settings)

--- a/test.js
+++ b/test.js
@@ -10,12 +10,13 @@ test('should throw if created without a method as first argument', t => {
 	t.notThrows(() => batcher(function () {}));
 });
 
-test('should throw if parameters are not passed to the batched call', t => {
-	t.plan(2);
+test('should not throw if no parameters are passed to the batched call', t => {
+	t.plan(3);
 
 	const batch = batcher(function () {});
 
-	t.throws(() => batch(), TypeError, 'Missing parameters in batched call');
+	t.notThrows(() => batch()); // No callback, e.g. batch MobX action (synchronous).
+	t.notThrows(() => batch(undefined, () => 123));
 	t.notThrows(() => batch({}, () => 123));
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "dom",
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "baseUrl": "./",
+    "typeRoots": [
+      "./"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "batcher-js-tests.ts"
+  ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tslint:latest"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,6 +57,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
 ansi-styles@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
@@ -827,6 +833,10 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -885,6 +895,13 @@ brace-expansion@^1.0.0:
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
   dependencies:
     balanced-match "^0.4.1"
+    concat-map "0.0.1"
+
+brace-expansion@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  dependencies:
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 braces@^1.8.2:
@@ -979,6 +996,14 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 chokidar@^1.4.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
@@ -1045,11 +1070,25 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+color-convert@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 common-path-prefix@^1.0.0:
   version "1.0.0"
@@ -1230,6 +1269,10 @@ diff-match-patch@^1.0.0:
 diff@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"
+
+diff@^3.2.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
 doctrine@1.3.x:
   version "1.3.0"
@@ -1753,6 +1796,17 @@ glob@^7.0.3, glob@^7.0.5:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2418,6 +2472,12 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     brace-expansion "^1.0.0"
 
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -3063,6 +3123,12 @@ resolve@^1.1.6:
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.3.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
+
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
@@ -3267,6 +3333,12 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+supports-color@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  dependencies:
+    has-flag "^2.0.0"
+
 symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
@@ -3387,6 +3459,32 @@ tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
 
+tslib@^1.7.1:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.0.tgz#dc604ebad64bcbf696d613da6c954aa0e7ea1eb6"
+
+tslint@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.8.0.tgz#1f49ad5b2e77c76c3af4ddcae552ae4e3612eb13"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.1.0"
+    commander "^2.9.0"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.7.1"
+    tsutils "^2.12.1"
+
+tsutils@^2.12.1:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.12.2.tgz#ad58a4865d17ec3ddb6631b6ca53be14a5656ff3"
+  dependencies:
+    tslib "^1.7.1"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -3410,6 +3508,10 @@ type-name@^2.0.1:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 
 uid-number@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Batcher helps me display loading animation.

Animation is shown when API request starts. It shouldn't hide immediately on request finish, because another request can start after a few ms, causing flicker. So instead, I delay and batch decreasing of active requests counter. No callback is involved, and only the number of calls matters.

Loading service exposes "start()", which increments, and "stop()", which decrements. Neither receives arguments, so if I replace "stop()" with a function that Batcher returns, it throws because first argument is undefined. I remove this check in my pull request because undefined is a valid type in this case.

On server, I want to keep the original "stop()" method because no render happens on counter change, so it can and should decrease instantly. Replacing "stop()" with Batcher happens in the "lazyStop()" method that is only called in browser.

Batcher only uses callback as group key, without calling it. So undefined works fine as the second argument too, resulting in one group as expected.

Type definitions make using Batcher in TypeScript apps easier, and tests ensure my case works as well as those the library was originally designed for.