### PR TITLE
fix: adding `index.d.ts` in published content

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "publish-to-npm": "(git pull origin master && npm version patch && git push origin master && npm publish && git push --tags)"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "keywords": [
     "batch",


### PR DESCRIPTION
Closes https://github.com/leandrowd/batcher/issues/8

This happens because this package is using `files`, which is adding only `index.js`. A quick solution is to add the type definition file into the list as well